### PR TITLE
Move xsl extension to application/xslt+xml

### DIFF
--- a/MimeSharp/MimeSharp.FromFile/MimeTypes/mime.types
+++ b/MimeSharp/MimeSharp.FromFile/MimeTypes/mime.types
@@ -1135,13 +1135,13 @@ application/xcap-diff+xml			xdf
 application/xenc+xml				xenc
 application/xhtml+xml				xhtml xht
 # application/xhtml-voice+xml
-application/xml					xml xsl
+application/xml					xml
 application/xml-dtd				dtd
 # application/xml-external-parsed-entity
 # application/xmpp+xml
 application/xop+xml				xop
 application/xproc+xml				xpl
-application/xslt+xml				xslt
+application/xslt+xml				xslt xsl
 application/xspf+xml				xspf
 application/xv+xml				mxml xhvml xvml xvm
 application/yang				yang


### PR DESCRIPTION
`.xsl` should be synonymous with `.xslt`, as they are 2 different extensions for the same file type. Therefore they should also have the same mime type.