### PR TITLE
Improvement to Fix for Issue #8.  Use a static constructor to support initialization.

### DIFF
--- a/MimeSharp/Mime.cs
+++ b/MimeSharp/Mime.cs
@@ -9,10 +9,7 @@ namespace MimeSharp
     public static class Mime
     {
         static readonly Dictionary<string, List<string>> ApacheMimes = new Dictionary<string, List<string>>();
-
         private static readonly string defaultType = "application/octet-stream";
-        private static bool isInitialized = false;
-        private static object padLock = new object();
 
         static Mime()
         {

--- a/MimeSharp/Mime.cs
+++ b/MimeSharp/Mime.cs
@@ -14,50 +14,43 @@ namespace MimeSharp
         private static bool isInitialized = false;
         private static object padLock = new object();
 
+        static Mime()
+        {
+            Init();
+        }
+
         private static void Init()
         {
-            //If we are initialized, no need to initialize again.
-            if (isInitialized) return;
+            var allApacheMimeTypes = ApacheMimeTypes.AllMimeTypes;
 
-            lock (padLock)
+            using (StringReader stringReader = new StringReader(allApacheMimeTypes))
             {
-                // Now that we have a lock, we need to recheck to make sure that we haven't already initialized on another thread.
-                // If we have, no need to initialize again.
-                if (isInitialized) return;
-
-                var allApacheMimeTypes = ApacheMimeTypes.AllMimeTypes;
-
-                using (StringReader stringReader = new StringReader(allApacheMimeTypes))
+                string line;
+                while ((line = stringReader.ReadLine()) != null)
                 {
-                    string line;
-                    while ((line = stringReader.ReadLine()) != null)
+                    //Remove comments
+                    var currentLine = Regex.Replace(line, @"\s*#.*|^\s*|\s*$/g", "");
+
+                    //split them by whitespace
+                    var stripWhiteSpaceRegEx = new Regex(@"\s+", RegexOptions.None);
+
+                    if (!String.IsNullOrEmpty(currentLine))
                     {
-                        //Remove comments
-                        var currentLine = Regex.Replace(line, @"\s*#.*|^\s*|\s*$/g", "");
+                        var matches = stripWhiteSpaceRegEx.Split(currentLine);
 
-                        //split them by whitespace
-                        var stripWhiteSpaceRegEx = new Regex(@"\s+", RegexOptions.None);
+                        //add the mime type and extension to the dictionary
+                        //mime-type is the key and value is the list of extensons it is associated with
+                        //e.g. {"application/mathematica":["ma","nb","mb"]}
 
-                        if (!String.IsNullOrEmpty(currentLine))
-                        {
-                            var matches = stripWhiteSpaceRegEx.Split(currentLine);
+                        ApacheMimes.Add(matches.First(), matches.Skip(1).ToList());
 
-                            //add the mime type and extension to the dictionary
-                            //mime-type is the key and value is the list of extensons it is associated with
-                            //e.g. {"application/mathematica":["ma","nb","mb"]}
-
-                            ApacheMimes.Add(matches.First(), matches.Skip(1).ToList());
-
-                        }
                     }
                 }
-                isInitialized = true;
             }
         }
 
         public static string Lookup(string filePath)
         {
-            Init();
             var extension = Path.GetExtension(filePath).ToLower();
 
             //remove dot from extenstion to lookup in the dictionary
@@ -83,7 +76,6 @@ namespace MimeSharp
 
         public static List<string> Extension(string mimeType)
         {
-            Init();
             var extensions = ApacheMimes.FirstOrDefault(x => x.Key.Equals(mimeType)).Value;
             if (extensions == null)
                 return new List<string>();


### PR DESCRIPTION
SteveK-GS makes an excellent point in his comment on Issue #8 regarding using a static constructor.  This simplifies the code as we no longer need to worry about synchronization and making sure the Init method only gets called once since the static constructor will do that for us.