### PR TITLE
Returning default type if there is no extension

### DIFF
--- a/MimeSharp/Mime.cs
+++ b/MimeSharp/Mime.cs
@@ -50,6 +50,10 @@ namespace MimeSharp
         {
             var extension = Path.GetExtension(filePath).ToLower();
 
+            //return default type if there is no extension
+            if (string.IsNullOrEmpty(extension))
+                return defaultType;
+
             //remove dot from extenstion to lookup in the dictionary
             extension = extension.Substring(1);
 


### PR DESCRIPTION
Path.GetExtension() returns empty string for files without extensions and subsequent Substring() caused an exception. 

Fixes https://github.com/ujjwol/MimeSharp/issues/4